### PR TITLE
fix indent, replace tabs with spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ Applying patches:
 var source = {
   "title": "Goodbye!",
   "author" : {
-		"givenName" : "John",
-		"familyName" : "Doe"
-	}
+    "givenName" : "John",
+    "familyName" : "Doe"
+  }
 };
 
 var patch = {
-	"title": 'Hello!',
-	"author": {
-		"familyName": null
-	}
+  "title": 'Hello!',
+  "author": {
+    "familyName": null
+  }
 }
 
 var target = jsonmergepatch.apply(source, patch);
 
 // target = {
-// 	"title": "Hello!",
+//   "title": "Hello!",
 //   "author" : {
-// 		"givenName" : "John",
-// 	}
+//     "givenName" : "John",
+//   }
 // }
 ```
 
@@ -61,14 +61,14 @@ var source = {
 };
 
 var target = {
-	"title": "Hello!",
+  "title": "Hello!",
 };
 
 var patch = jsonmergepatch.generate(source, target);
 
 // patch = {
-// 	"title": 'Hello!',
-// 	"author": null
+//   "title": 'Hello!',
+//   "author": null
 // }
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "mocha": "^2.3.2"
   },
   "scripts": {
-    "test": "NODE_ENV=test mocha -b --reporter spec --recursive test",
-    "lint": "eslint ./lib ./index.js",
-    "coverage": "istanbul cover _mocha -- -R spec --recursive test",
-    "coveralls": "istanbul cover _mocha -- -R spec --recursive test; cat ./coverage/lcov.info | coveralls.js || true"
+    "test": "NODE_ENV=test ./node_modules/.bin/mocha -b --reporter spec --recursive test",
+    "lint": "./node_modules/.bin/eslint ./lib ./index.js",
+    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec --recursive test",
+    "coveralls": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- -R spec --recursive test; cat ./coverage/lcov.info | ./node_modules/.bin/coveralls || true"
   },
   "repository": {
     "type": "git",

--- a/test/fixtures/index.json
+++ b/test/fixtures/index.json
@@ -1,190 +1,190 @@
 [
-    {
-        "original": {
-            "a": "b"
-        },
-        "patch": {
-            "a": "c"
-        },
-        "result": {
-            "a": "c"
-        }
+  {
+    "original": {
+      "a": "b"
     },
-    {
-        "original": {
-            "a": "b"
-        },
-        "patch": {
-            "b": "c"
-        },
-        "result": {
-            "a": "b",
-            "b": "c"
-        }
+    "patch": {
+      "a": "c"
     },
-    {
-        "original": {
-            "a": "b"
-        },
-        "patch": {
-            "a": null
-        },
-        "result": {}
-    },
-    {
-        "original": {
-            "a": "b",
-            "b": "c"
-        },
-        "patch": {
-            "a": null
-        },
-        "result": {
-            "b": "c"
-        }
-    },
-    {
-        "original": {
-            "a": [
-                "b"
-            ]
-        },
-        "patch": {
-            "a": "c"
-        },
-        "result": {
-            "a": "c"
-        }
-    },
-    {
-        "original": {
-            "a": "c"
-        },
-        "patch": {
-            "a": [
-                "b"
-            ]
-        },
-        "result": {
-            "a": [
-                "b"
-            ]
-        }
-    },
-    {
-        "original": {
-            "a": {
-                "b": "c"
-            }
-        },
-        "patch": {
-            "a": {
-                "b": "d",
-                "c": null
-            }
-        },
-        "result": {
-            "a": {
-                "b": "d"
-            }
-        }
-    },
-    {
-        "original": {
-            "a": [
-                {
-                    "b": "c"
-                }
-            ]
-        },
-        "patch": {
-            "a": [
-                1
-            ]
-        },
-        "result": {
-            "a": [
-                1
-            ]
-        }
-    },
-    {
-        "original": [
-            "a",
-            "b"
-        ],
-        "patch": [
-            "c",
-            "d"
-        ],
-        "result": [
-            "c",
-            "d"
-        ]
-    },
-    {
-        "original": {
-            "a": "b"
-        },
-        "patch": [
-            "c"
-        ],
-        "result": [
-            "c"
-        ]
-    },
-    {
-        "original": {
-            "a": "foo"
-        },
-        "patch": null,
-        "result": null
-    },
-    {
-        "original": {
-            "a": "foo"
-        },
-        "patch": "bar",
-        "result": "bar"
-    },
-    {
-        "original": {
-            "e": null
-        },
-        "patch": {
-            "a": 1
-        },
-        "result": {
-            "e": null,
-            "a": 1
-        }
-    },
-    {
-        "original": [
-            1,
-            2
-        ],
-        "patch": {
-            "a": "b",
-            "c": null
-        },
-        "result": {
-            "a": "b"
-        }
-    },
-    {
-        "original": {},
-        "patch": {
-            "a": {
-                "bb": {
-                    "ccc": null
-                }
-            }
-        },
-        "result": {
-            "a": {
-                "bb": {}
-            }
-        }
+    "result": {
+      "a": "c"
     }
+  },
+  {
+    "original": {
+      "a": "b"
+    },
+    "patch": {
+      "b": "c"
+    },
+    "result": {
+      "a": "b",
+      "b": "c"
+    }
+  },
+  {
+    "original": {
+      "a": "b"
+    },
+    "patch": {
+      "a": null
+    },
+    "result": {}
+  },
+  {
+    "original": {
+      "a": "b",
+      "b": "c"
+    },
+    "patch": {
+      "a": null
+    },
+    "result": {
+      "b": "c"
+    }
+  },
+  {
+    "original": {
+      "a": [
+        "b"
+      ]
+    },
+    "patch": {
+      "a": "c"
+    },
+    "result": {
+      "a": "c"
+    }
+  },
+  {
+    "original": {
+      "a": "c"
+    },
+    "patch": {
+      "a": [
+        "b"
+      ]
+    },
+    "result": {
+      "a": [
+        "b"
+      ]
+    }
+  },
+  {
+    "original": {
+      "a": {
+        "b": "c"
+      }
+    },
+    "patch": {
+      "a": {
+        "b": "d",
+        "c": null
+      }
+    },
+    "result": {
+      "a": {
+        "b": "d"
+      }
+    }
+  },
+  {
+    "original": {
+      "a": [
+        {
+          "b": "c"
+        }
+      ]
+    },
+    "patch": {
+      "a": [
+        1
+      ]
+    },
+    "result": {
+      "a": [
+        1
+      ]
+    }
+  },
+  {
+    "original": [
+      "a",
+      "b"
+    ],
+    "patch": [
+      "c",
+      "d"
+    ],
+    "result": [
+      "c",
+      "d"
+    ]
+  },
+  {
+    "original": {
+      "a": "b"
+    },
+    "patch": [
+      "c"
+    ],
+    "result": [
+      "c"
+    ]
+  },
+  {
+    "original": {
+      "a": "foo"
+    },
+    "patch": null,
+    "result": null
+  },
+  {
+    "original": {
+      "a": "foo"
+    },
+    "patch": "bar",
+    "result": "bar"
+  },
+  {
+    "original": {
+      "e": null
+    },
+    "patch": {
+      "a": 1
+    },
+    "result": {
+      "e": null,
+      "a": 1
+    }
+  },
+  {
+    "original": [
+      1,
+      2
+    ],
+    "patch": {
+      "a": "b",
+      "c": null
+    },
+    "result": {
+      "a": "b"
+    }
+  },
+  {
+    "original": {},
+    "patch": {
+      "a": {
+        "bb": {
+          "ccc": null
+        }
+      }
+    },
+    "result": {
+      "a": {
+        "bb": {}
+      }
+    }
+  }
 ]

--- a/test/lib/apply.js
+++ b/test/lib/apply.js
@@ -5,108 +5,108 @@ var assert = require('chai').assert;
 var apply = require('../../lib/apply');
 
 describe('apply', function() {
-	it('should replace an attribute', function() {
-		assert.deepEqual(
-			apply({a: 'b'}, {a: 'c'}),
-	    {a: 'c'}
+  it('should replace an attribute', function() {
+    assert.deepEqual(
+      apply({a: 'b'}, {a: 'c'}),
+      {a: 'c'}
     );
-	});
+  });
 
-	it('should add an attribute', function() {
-		assert.deepEqual(
-			apply({a: 'b'}, {b: 'c'}),
-	    {a: 'b', b: 'c'}
+  it('should add an attribute', function() {
+    assert.deepEqual(
+      apply({a: 'b'}, {b: 'c'}),
+      {a: 'b', b: 'c'}
     );
-	});
+  });
 
-	it('should delete attribute', function() {
-		assert.deepEqual(
-			apply({a: 'b'}, {a: null}),
-	    {}
+  it('should delete attribute', function() {
+    assert.deepEqual(
+      apply({a: 'b'}, {a: null}),
+      {}
     );
-	});
+  });
 
-	it('should delete attribute without affecting others', function() {
-		assert.deepEqual(
-			apply({a: 'b', b: 'c'}, {a: null}),
-	    {b: 'c'}
+  it('should delete attribute without affecting others', function() {
+    assert.deepEqual(
+      apply({a: 'b', b: 'c'}, {a: null}),
+      {b: 'c'}
     );
-	});
+  });
 
-	it('should replace array with a string', function() {
-		assert.deepEqual(
-			apply({a: ['b']}, {a: 'c'}),
-	    {a: 'c'}
+  it('should replace array with a string', function() {
+    assert.deepEqual(
+      apply({a: ['b']}, {a: 'c'}),
+      {a: 'c'}
     );
-	});
+  });
 
-	it('should replace an string with an array', function() {
-		assert.deepEqual(
-			apply({a: 'c'}, {a: ['b']}),
-	    {a: ['b']}
+  it('should replace an string with an array', function() {
+    assert.deepEqual(
+      apply({a: 'c'}, {a: ['b']}),
+      {a: ['b']}
     );
-	});
+  });
 
-	it('should apply recursively', function() {
-		assert.deepEqual(
-			apply({a: {b: 'c'}}, {a: {b: 'd', c: null}}),
-	    {a: {b: 'd'}}
+  it('should apply recursively', function() {
+    assert.deepEqual(
+      apply({a: {b: 'c'}}, {a: {b: 'd', c: null}}),
+      {a: {b: 'd'}}
     );
-	});
+  });
 
-	it('should replace an object array with a number array', function() {
-		assert.deepEqual(
-			apply({a: [{b: 'c'}]}, {a: [1]}),
-	    {a: [1]}
+  it('should replace an object array with a number array', function() {
+    assert.deepEqual(
+      apply({a: [{b: 'c'}]}, {a: [1]}),
+      {a: [1]}
     );
-	});
+  });
 
-	it('should replace an array', function() {
-		assert.deepEqual(
-			apply(['a', 'b'], ['c', 'd']),
-			['c', 'd']
+  it('should replace an array', function() {
+    assert.deepEqual(
+      apply(['a', 'b'], ['c', 'd']),
+      ['c', 'd']
     );
-	});
+  });
 
-	it('should replace an object with an array', function() {
-		assert.deepEqual(
-			apply({a: 'b'}, ['c']),
-			['c']
+  it('should replace an object with an array', function() {
+    assert.deepEqual(
+      apply({a: 'b'}, ['c']),
+      ['c']
     );
-	});
+  });
 
-	it('should replace an object with null', function() {
-		assert.deepEqual(
-			apply({a: 'foo'}, null),
-			null
+  it('should replace an object with null', function() {
+    assert.deepEqual(
+      apply({a: 'foo'}, null),
+      null
     );
-	});
+  });
 
-	it('should replace an object with a string', function() {
-		assert.deepEqual(
-			apply({a: 'foo'}, 'bar'),
-			'bar'
+  it('should replace an object with a string', function() {
+    assert.deepEqual(
+      apply({a: 'foo'}, 'bar'),
+      'bar'
     );
-	});
+  });
 
-	it('should not change null attributes', function() {
-		assert.deepEqual(
-			apply({e: null}, {a: 1}),
-			{e: null, a: 1}
+  it('should not change null attributes', function() {
+    assert.deepEqual(
+      apply({e: null}, {a: 1}),
+      {e: null, a: 1}
     );
-	});
+  });
 
-	it('should not set an attribute to null', function() {
-		assert.deepEqual(
-			apply([1, 2], {a: 'b', c: null}),
-			{a: 'b'}
+  it('should not set an attribute to null', function() {
+    assert.deepEqual(
+      apply([1, 2], {a: 'b', c: null}),
+      {a: 'b'}
     );
-	});
+  });
 
-	it('should not set an attribute to null in a sub object', function() {
-		assert.deepEqual(
-			apply({}, {a: {bb: {ccc: null}}}),
-			{a: {bb: {}}}
-		);
-	});
+  it('should not set an attribute to null in a sub object', function() {
+    assert.deepEqual(
+      apply({}, {a: {bb: {ccc: null}}}),
+      {a: {bb: {}}}
+    );
+  });
 });

--- a/test/lib/generate.js
+++ b/test/lib/generate.js
@@ -5,123 +5,123 @@ var assert = require('chai').assert;
 var generate = require('../../lib/generate');
 
 describe('generate', function() {
-	it('should generate a patch replacing an attribute', function() {
-		assert.deepEqual(
-			generate({a: 'b'}, {a: 'c'}),
-	    {a: 'c'}
+  it('should generate a patch replacing an attribute', function() {
+    assert.deepEqual(
+      generate({a: 'b'}, {a: 'c'}),
+      {a: 'c'}
     );
-	});
+  });
 
-	it('should generate a patch adding an attribute', function() {
-		assert.deepEqual(
-			generate({a: 'b'}, { a: 'b', b: 'c'}),
-			{b: 'c'}
+  it('should generate a patch adding an attribute', function() {
+    assert.deepEqual(
+      generate({a: 'b'}, { a: 'b', b: 'c'}),
+      {b: 'c'}
     );
-	});
+  });
 
-	it('should generate a patch deleting an attribute', function() {
-		assert.deepEqual(
-			generate({a: 'b'}, {}),
-			{a: null}
+  it('should generate a patch deleting an attribute', function() {
+    assert.deepEqual(
+      generate({a: 'b'}, {}),
+      {a: null}
     );
-	});
+  });
 
-	it('should generate a patch deleting an attribute without affecting others', function() {
-		assert.deepEqual(
-			generate({a: 'b', b: 'c'}, {b: 'c'}),
-			{a: null}
-		);
-	});
+  it('should generate a patch deleting an attribute without affecting others', function() {
+    assert.deepEqual(
+      generate({a: 'b', b: 'c'}, {b: 'c'}),
+      {a: null}
+    );
+  });
 
-	it('should generate a patch replacing an attribute if its an array', function() {
-		assert.deepEqual(
-			generate({a: ['b']}, {a: 'c'}),
-			{a: 'c'}
-		);
-	});
+  it('should generate a patch replacing an attribute if its an array', function() {
+    assert.deepEqual(
+      generate({a: ['b']}, {a: 'c'}),
+      {a: 'c'}
+    );
+  });
 
-	it('should generate a patch replacing the attribute with an array', function() {
-		assert.deepEqual(
-			generate({a: 'c'}, {a: ['b']}),
-			{a: ['b']}
-		);
-	});
+  it('should generate a patch replacing the attribute with an array', function() {
+    assert.deepEqual(
+      generate({a: 'c'}, {a: ['b']}),
+      {a: ['b']}
+    );
+  });
 
-	it('should generate a patch replacing an object array with a number array', function() {
-		assert.deepEqual(
-			generate({a: [{b: 'c'}]}, {a: [1]}),
-			{a: [1]}
-		);
-	});
+  it('should generate a patch replacing an object array with a number array', function() {
+    assert.deepEqual(
+      generate({a: [{b: 'c'}]}, {a: [1]}),
+      {a: [1]}
+    );
+  });
 
-	it('should generate a patch replacing whole array if one element has changed', function() {
-		assert.deepEqual(
-			generate(['a', 'b'], ['c', 'd']),
-			['c', 'd']
-		);
-	});
+  it('should generate a patch replacing whole array if one element has changed', function() {
+    assert.deepEqual(
+      generate(['a', 'b'], ['c', 'd']),
+      ['c', 'd']
+    );
+  });
 
-	it('should generate a patch replacing whole array if one element has been deleted', function() {
-		assert.deepEqual(
-			generate(['a', 'b'], ['a']),
-			['a']
-		);
-	});
+  it('should generate a patch replacing whole array if one element has been deleted', function() {
+    assert.deepEqual(
+      generate(['a', 'b'], ['a']),
+      ['a']
+    );
+  });
 
-	it('should generate a patch replacing with an array', function() {
-		assert.deepEqual(
-			generate({a: 'b'}, ['c']),
-			['c']
-		);
-	});
+  it('should generate a patch replacing with an array', function() {
+    assert.deepEqual(
+      generate({a: 'b'}, ['c']),
+      ['c']
+    );
+  });
 
-	it('should generate a patch replacing with null', function() {
-		assert.deepEqual(
-			generate({a: 'foo'}, null),
-			null
-		);
-	});
+  it('should generate a patch replacing with null', function() {
+    assert.deepEqual(
+      generate({a: 'foo'}, null),
+      null
+    );
+  });
 
-	it('should generate a patch replacing with a string', function() {
-		assert.deepEqual(
-			generate({a: 'foo'}, 'bar'),
-			'bar'
-		);
-	});
+  it('should generate a patch replacing with a string', function() {
+    assert.deepEqual(
+      generate({a: 'foo'}, 'bar'),
+      'bar'
+    );
+  });
 
-	it('should generate a patch keeping null attributes', function() {
-		assert.deepEqual(
-			generate({e: null}, {e: null, a: 1}),
-			{a: 1}
-		);
-	});
+  it('should generate a patch keeping null attributes', function() {
+    assert.deepEqual(
+      generate({e: null}, {e: null, a: 1}),
+      {a: 1}
+    );
+  });
 
-	it('should work recursively', function() {
-		assert.deepEqual(
-			generate({}, {a: {bb: {}}}),
-			{a: {bb: {}}}
-		);
-	});
+  it('should work recursively', function() {
+    assert.deepEqual(
+      generate({}, {a: {bb: {}}}),
+      {a: {bb: {}}}
+    );
+  });
 
-	it('should return undefined if the object hasnt changed', function() {
-		assert.deepEqual(
-			generate({a: 'a'}, {a: 'a'}),
-			undefined
-		);
-	});
+  it('should return undefined if the object hasnt changed', function() {
+    assert.deepEqual(
+      generate({a: 'a'}, {a: 'a'}),
+      undefined
+    );
+  });
 
-	it('should return undefined if the object with sub attributes hasnt changed', function() {
-		assert.deepEqual(
-			generate({a: {b: 'c'}}, {a: {b: 'c'}}),
-			undefined
-		);
-	});
+  it('should return undefined if the object with sub attributes hasnt changed', function() {
+    assert.deepEqual(
+      generate({a: {b: 'c'}}, {a: {b: 'c'}}),
+      undefined
+    );
+  });
 
-	it('should return undefined if the array hasnt changed', function() {
-		assert.deepEqual(
-			generate([1,2,3], [1,2,3]),
-			undefined
-		);
-	});
+  it('should return undefined if the array hasnt changed', function() {
+    assert.deepEqual(
+      generate([1,2,3], [1,2,3]),
+      undefined
+    );
+  });
 
 });

--- a/test/lib/merge.js
+++ b/test/lib/merge.js
@@ -6,80 +6,80 @@ var merge = require('../../lib/merge');
 
 describe('merge', function() {
 
-	it('should merge 2 patches with different attributes', function() {
-		assert.deepEqual(
-			merge({a: 'b'}, {b: 'c'}),
-	    {a: 'b', b: 'c'}
+  it('should merge 2 patches with different attributes', function() {
+    assert.deepEqual(
+      merge({a: 'b'}, {b: 'c'}),
+      {a: 'b', b: 'c'}
     );
-	});
+  });
 
-	it('should merge take last patch attributes for rewriting', function() {
-		assert.deepEqual(
-			merge({a: 'b'}, {a: 'c'}),
-			{a: 'c'}
+  it('should merge take last patch attributes for rewriting', function() {
+    assert.deepEqual(
+      merge({a: 'b'}, {a: 'c'}),
+      {a: 'c'}
     );
-	});
+  });
 
-	it('should merge take last patch attributes for rewriting and keep other attributes', function() {
-		assert.deepEqual(
-			merge({a: 'b', b: 'd'}, {a: 'c'}),
-			{a: 'c', b: 'd'}
+  it('should merge take last patch attributes for rewriting and keep other attributes', function() {
+    assert.deepEqual(
+      merge({a: 'b', b: 'd'}, {a: 'c'}),
+      {a: 'c', b: 'd'}
     );
-	});
+  });
 
-	it('should keep null attributes for deleting', function() {
-		assert.deepEqual(
-			merge({a: null}, {b: 'c'}),
-			{a: null, b: 'c'}
+  it('should keep null attributes for deleting', function() {
+    assert.deepEqual(
+      merge({a: null}, {b: 'c'}),
+      {a: null, b: 'c'}
     );
-	});
+  });
 
-	it('should replace null with newer attribute', function() {
-		assert.deepEqual(
-			merge({a: null}, {a: 'b'}),
-			{a: 'b'}
-		);
-	});
+  it('should replace null with newer attribute', function() {
+    assert.deepEqual(
+      merge({a: null}, {a: 'b'}),
+      {a: 'b'}
+    );
+  });
 
-	it('should replace an attribute with null if newer', function() {
-		assert.deepEqual(
-			merge({a: 'b'}, {a: null}),
-			{a: null}
-		);
-	});
+  it('should replace an attribute with null if newer', function() {
+    assert.deepEqual(
+      merge({a: 'b'}, {a: null}),
+      {a: null}
+    );
+  });
 
-	it('should replace an array with an object', function() {
-		assert.deepEqual(
-			merge([], {a: 'b'}),
-			{a: 'b'}
-		);
-	});
+  it('should replace an array with an object', function() {
+    assert.deepEqual(
+      merge([], {a: 'b'}),
+      {a: 'b'}
+    );
+  });
 
-	it('should replace an object with an array', function() {
-		assert.deepEqual(
-			merge({a: 'b'}, []),
-			[]
-		);
-	});
+  it('should replace an object with an array', function() {
+    assert.deepEqual(
+      merge({a: 'b'}, []),
+      []
+    );
+  });
 
-	it('should merge sub objects', function() {
-		assert.deepEqual(
-			merge({a: {b: {c: 'd'}}, d: 'e'}, {a: {b: 'a'}}),
-			{a: {b: 'a'}, d: 'e'}
-		);
-	});
+  it('should merge sub objects', function() {
+    assert.deepEqual(
+      merge({a: {b: {c: 'd'}}, d: 'e'}, {a: {b: 'a'}}),
+      {a: {b: 'a'}, d: 'e'}
+    );
+  });
 
-	it('should merge recursively', function() {
-		assert.deepEqual(
-			merge({a: {b: {c: 'd'}, d: 'e'}}, {a: {b: {c: 'e'}}}),
-			{a: {b: {c: 'e'}, d: 'e'}}
-		);
-	});
+  it('should merge recursively', function() {
+    assert.deepEqual(
+      merge({a: {b: {c: 'd'}, d: 'e'}}, {a: {b: {c: 'e'}}}),
+      {a: {b: {c: 'e'}, d: 'e'}}
+    );
+  });
 
-	it('should replace object with with null value', function() {
-		assert.deepEqual(
-			merge({a: 'b'}, null),
-			null
-		);
-	});
+  it('should replace object with with null value', function() {
+    assert.deepEqual(
+      merge({a: 'b'}, null),
+      null
+    );
+  });
 });


### PR DESCRIPTION
NPM scripts' paths to binaries have also been fixed to avoid having to `npm install -g everything`.
Hope it pleases you.
Cheers!

Protip: you can visualize changes ignoring whitespace at https://github.com/pierreinglebert/json-merge-patch/pull/6/files?w=1.
