### PR TITLE
Generate the identity when running `generate(a,a)`

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -19,11 +19,6 @@ module.exports = function generate(before, after) {
   before = serialize(before);
   after = serialize(after);
 
-  // An undefined target is a deletion attempt
-  if (after === undefined) {
-    return null;
-  }
-
   if (!(before instanceof Object) &&
       !(after instanceof Object) &&
       before === after) { // Return no op when values match
@@ -38,7 +33,7 @@ module.exports = function generate(before, after) {
 
   let patch = {};
   for (let key of Object.keys(before)) {
-    let newVal = generate(before[key], after[key]);
+    let newVal = generate(before[key] ?? null, after[key] ?? null);
     // Omit noops
     if (equal(newVal, {})) {
       continue;

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -19,6 +19,11 @@ module.exports = function generate(before, after) {
   before = serialize(before);
   after = serialize(after);
 
+  // An undefined target is a deletion attempt
+  if (after === undefined) {
+    return null;
+  }
+
   if (!(before instanceof Object) &&
       !(after instanceof Object) &&
       before === after) { // Return no op when values match
@@ -33,10 +38,8 @@ module.exports = function generate(before, after) {
 
   let patch = {};
   for (let key of Object.keys(before)) {
-    let newVal = null;
-    if (key in after) {
-      newVal = generate(before[key], after[key]);
-    }
+    let newVal = generate(before[key], after[key]);
+    // Omit noops
     if (equal(newVal, {})) {
       continue;
     }

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -19,53 +19,35 @@ module.exports = function generate(before, after) {
   before = serialize(before);
   after = serialize(after);
 
+  if (!(before instanceof Object) &&
+      !(after instanceof Object) &&
+      before === after) { // Return no op when values match
+    return {}
+  }
+
   if (before === null || after === null ||
     typeof before !== 'object' || typeof after !== 'object' ||
-    Array.isArray(before) !== Array.isArray(after)) {
-    return after;
+    Array.isArray(before) || Array.isArray(after)) {
+    return serialize(after);
   }
 
-  if (Array.isArray(before)) {
-    if (!arrayEquals(before, after)) {
-      return after;
+  let patch = {};
+  for (let key of Object.keys(before)) {
+    let newVal = null;
+    if (key in after) {
+      newVal = generate(before[key], after[key]);
     }
-    return undefined;
+    if (equal(newVal, {})) {
+      continue;
+    }
+    patch[key] = serialize(newVal);
   }
 
-  var patch = {};
-  var beforeKeys = Object.keys(before);
-  var afterKeys = Object.keys(after);
-
-  var key, i;
-
-  // new elements
-  var newKeys = {};
-  for (i = 0; i < afterKeys.length; i++) {
-    key = afterKeys[i];
-    if (beforeKeys.indexOf(key) === -1) {
-      newKeys[key] = true;
+  for (let key of Object.keys(after)) {
+    if (!(key in before)) {
       patch[key] = serialize(after[key]);
     }
   }
 
-  // removed & modified elements
-  var removedKeys = {};
-  for (i = 0; i < beforeKeys.length; i++) {
-    key = beforeKeys[i];
-    if (afterKeys.indexOf(key) === -1) {
-      removedKeys[key] = true;
-      patch[key] = null;
-    } else {
-      if (before[key] !== null && typeof before[key] === 'object') {
-        var subPatch = generate(before[key], after[key]);
-        if (subPatch !== undefined) {
-          patch[key] = subPatch;
-        }
-      } else if (before[key] !== after[key]) {
-        patch[key] = serialize(after[key]);
-      }
-    }
-  }
-
-  return (Object.keys(patch).length > 0 ? patch : undefined);
+  return (Object.keys(patch).length > 0 ? patch : {});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-merge-patch",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Implementation of JSON Merge Patch (RFC 7396)",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-merge-patch",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Implementation of JSON Merge Patch (RFC 7396)",
   "main": "index.js",
   "directories": {

--- a/test/lib/generate.js
+++ b/test/lib/generate.js
@@ -126,24 +126,24 @@ describe('generate', function() {
     );
   });
 
-  it('should return undefined if the object hasnt changed', function() {
+  it('should return {} if the object hasnt changed', function() {
     assert.deepEqual(
       generate({a: 'a'}, {a: 'a'}),
-      undefined
+      {}
     );
   });
 
-  it('should return undefined if the object with sub attributes hasnt changed', function() {
+  it('should return {} if the object with sub attributes hasnt changed', function() {
     assert.deepEqual(
       generate({a: {b: 'c'}}, {a: {b: 'c'}}),
-      undefined
+      {}
     );
   });
 
-  it('should return undefined if the array hasnt changed', function() {
+  it('should return the target if the output is an array', function() {
     assert.deepEqual(
       generate([1, 2, 3], [1, 2, 3]),
-      undefined
+      [1,2,3]
     );
   });
 


### PR DESCRIPTION
According to the RFC, `apply(a, {})` is a noop. However when running `generate(a,a)` the output is `undefined`. This is undesirable since then the result of doing `apply(a, generate(a,a))` is not `a`.

This patch updates the function generate to instead return `{}` in cases where nothing should be changed.

This also changes the result of some tests. I have updated the tests to expect the new result but I that this likely results in breaking changes for users.